### PR TITLE
Don't require manually relative to `./node_modules`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var mjAPI = require("./node_modules/mathjax-node/lib/mj-page.js");
+var mjAPI = require("mathjax-node/lib/mj-page.js");
 var jsdom = require("jsdom");
 var debug = require('debug')('metalsmith-mathjax');
 var async = require('async');
@@ -32,7 +32,7 @@ function plugin(opts) {
                     done: function(err, window) {
                         if (err) {
                         	console.log("We have an error");
-                            throw(err);
+                          throw(err);
                         }
                         mjAPI.start();
 


### PR DESCRIPTION
Hi @wilson428,

I've tried to use this metalsmith plugin but it couldn't find `mathjax-node` because you require it from relative your `./node-modules` path. This works in isolation, but if I add your plugin as dependency, the mathjax-node path may actually be nested underneath your module in the dependency tree.

Node can find the correct path automatically, if you just change the require statement slightly. 
