### PR TITLE
Option to configure `mathjax-node-page`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,30 @@
 # metalsmith-mathjax
-Prerender mathjax in metalsmith
 
-##Usage
+Prerender LaTeX, MathML, and AsciiMath notation using [MathJax](https://github.com/mathjax/MathJax) in Metalsmith.
 
-Just add `mathjax: true` in the gray matter and this plugin will prerender your MathJax as SVG. This cuts down on the Javascript overhead and eliminates the delay one typically sees where the raw TeX renders for a second before MathJax loads.
+## Installation
 
-Of course, you also need to add the plugin to `metalsmith.json`.
+Use npm to easily install this package and its dependencies.
 
-Right now, it's zero-config. Happy for suggestions.
+```
+npm install --save metalsmith-mathjax
+```
 
-##License
+## Usage
+
+Just add `mathjax: true` in the gray matter and this plugin will prerender your math notation as SVG using MathJax. This cuts down on the JavaScript overhead and eliminates the delay one typically sees where the raw TeX renders for a second before MathJax loads.
+
+## Options
+
+You can pass options to `metalsmith-mathjax` to define the parameters `mjpageConfig` and `mjnodeConfig` of [`mathjax-node-page`](https://github.com/pkra/mathjax-node-page#usage). By default, the options are set to
+
+```javascript
+{
+    mjpageConfig: {format: ["TeX"]},
+    mjnodeConfig: {svg: true}
+}
+```
+
+## License
+
 MIT

--- a/index.js
+++ b/index.js
@@ -1,22 +1,15 @@
 var mjAPI = require("mathjax-node-page");
-//var mjAPI = require("mathjax-node");
-var jsdom = require("jsdom");
+var defaults = require("lodash").defaults;
 var debug = require('debug')('metalsmith-mathjax');
 var async = require('async');
 
-/**
- * Expose `plugin`.
- */
-
 module.exports = plugin;
 
-/**
- * Metalsmith plugin to hide drafts from the output.
- *
- * @return {Function}
- */
-
-function plugin(opts) {
+function plugin(options = {}) {
+    defaults(options, {
+        mjpageConfig: {format: ["TeX"]},
+        mjnodeConfig: {svg: true}
+    })
     return function(files, metalsmith, done) {
         async.eachSeries(Object.keys(files), prerender, done);
 
@@ -25,14 +18,12 @@ function plugin(opts) {
             if (!data.mathjax) {
                 done();
             } else {
-                debug("Found mathjax in", file);
+                debug("Found math notation in", file);
                 var contents = data.contents.toString('utf8');
 
-                mjAPI.mjpage(contents, {format: ["TeX"]}, {svg: true}, function(result) {
-                    // window.document.body.innerHTML = result.html;
-                    // var HTML = "<!DOCTYPE html>\n" + window.document.documentElement.outerHTML.replace(/^(\n|\s)*/, "");
+                mjAPI.mjpage(contents, options.mjpageConfig, options.mjnodeConfig, function(result) {
                     data.contents = new Buffer(result);
-                    debug('Prerendered MathJAX for file: %s', file);
+                    debug('Prerendered math for file: %s', file);
                     done();
                 });
             }

--- a/package.json
+++ b/package.json
@@ -1,25 +1,20 @@
 {
   "name": "metalsmith-mathjax",
-  "version": "0.0.7",
-  "description": "Prerender MathJAX during metalsmith build",
+  "version": "0.0.8",
+  "description": "Prerender MathJax during metalsmith build",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "keywords": [
     "metalsmith",
-    "MathJAX"
+    "MathJax"
   ],
   "author": "Chris Wilson",
   "license": "MIT",
   "dependencies": {
     "async": "^2.0.1",
     "debug": "^2.2.0",
-    "jsdom": "^9.4.2",
-    "mathjax-node": "^1.0.0-beta.0",
-    "mathjax-node-page": "github:pkra/mathjax-node-page"
+    "lodash": "^4.17.10",
+    "mathjax-node-page": "^2.0.0"
   },
-  "devDependencies": {},
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wilson428/metalsmith-mathjax.git"


### PR DESCRIPTION
The inability to configure `mathjax-node-page` in the plugin made it impossible to prerender inline equations.

This pull request exposes the configuration variables `mjpageConfig` and `mjnodeConfig` from [`mathjax-node-page`](https://github.com/pkra/mathjax-node-page#usage) as attributes of an `options` parameter.